### PR TITLE
remove unused headers from validate token routes

### DIFF
--- a/server/action/organisation/application/space/token/validate.go
+++ b/server/action/organisation/application/space/token/validate.go
@@ -4,29 +4,18 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/factly/kavach-server/model"
 	"github.com/factly/x/errorx"
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/renderx"
 	"github.com/factly/x/validationx"
-	"github.com/go-chi/chi"
 )
 
-
-
 func Validate(w http.ResponseWriter, r *http.Request) {
-	sID := chi.URLParam(r, "space_id")
-	spaceID, err := strconv.Atoi(sID)
-	if err != nil {
-		loggerx.Error(err)
-		errorx.Render(w, errorx.Parser(errorx.InvalidID()))
-		return
-	}
 
 	tokenBody := model.ValidationBody{}
-	err = json.NewDecoder(r.Body).Decode(&tokenBody)
+	err := json.NewDecoder(r.Body).Decode(&tokenBody)
 	if err != nil {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.DecodeError()))
@@ -47,11 +36,6 @@ func Validate(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.Unauthorized()))
-		return
-	}
-
-	if spaceToken.SpaceID != uint(spaceID) {
-		renderx.JSON(w, http.StatusUnauthorized, map[string]interface{}{"valid": false})
 		return
 	}
 

--- a/server/action/organisation/application/token/validate.go
+++ b/server/action/organisation/application/token/validate.go
@@ -4,14 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/factly/kavach-server/model"
 	"github.com/factly/x/errorx"
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/renderx"
 	"github.com/factly/x/validationx"
-	"github.com/go-chi/chi"
 	"gorm.io/gorm"
 )
 
@@ -32,20 +30,10 @@ type validationBody struct {
 // @Success 200 {object} model.Application
 // @Router /applications/{application_id}/tokens/validate [post]
 func validate(w http.ResponseWriter, r *http.Request) {
-	applicaion_id := chi.URLParam(r, "application_id")
-	// if applicaion_id == "" {
-	// 	errorx.Render(w, errorx.Parser(errorx.GetMessage("invalid id", http.StatusBadRequest)))
-	// 	return
-	// }
-	id, err := strconv.ParseUint(applicaion_id, 10, 64)
-	if err != nil {
-		errorx.Render(w, errorx.Parser(errorx.GetMessage("invalid id", http.StatusBadRequest)))
-		return
-	}
 	//parse applicaion_id
 
 	tokenBody := validationBody{}
-	err = json.NewDecoder(r.Body).Decode(&tokenBody)
+	err := json.NewDecoder(r.Body).Decode(&tokenBody)
 	if err != nil {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.DecodeError()))
@@ -61,8 +49,9 @@ func validate(w http.ResponseWriter, r *http.Request) {
 
 	appToken := model.ApplicationToken{}
 	// Fetch all tokens for a application
+	// to need to specify the organisation id as token itself is unique
 	err = model.DB.Model(&model.ApplicationToken{}).Preload("Application").Where(&model.ApplicationToken{
-		Token: tokenBody.Token, ApplicationID: uint(id),
+		Token: tokenBody.Token,
 	}).First(&appToken).Error
 
 	if err != nil {

--- a/server/action/organisation/token/validate.go
+++ b/server/action/organisation/token/validate.go
@@ -4,14 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/factly/kavach-server/model"
 	"github.com/factly/x/errorx"
 	"github.com/factly/x/loggerx"
 	"github.com/factly/x/renderx"
 	"github.com/factly/x/validationx"
-	"github.com/go-chi/chi"
 	"gorm.io/gorm"
 )
 
@@ -32,20 +30,10 @@ type validationBody struct {
 // @Success 200 {object} model.organisation
 // @Router /organisations/{application_id}/tokens/validate [post]
 func validate(w http.ResponseWriter, r *http.Request) {
-	organisation_id := chi.URLParam(r, "organisation_id")
-	if organisation_id == "" {
-		errorx.Render(w, errorx.Parser(errorx.GetMessage("invalid id", http.StatusBadRequest)))
-		return
-	}
-	id, err := strconv.ParseUint(organisation_id, 10, 64)
-	if err != nil {
-		errorx.Render(w, errorx.Parser(errorx.GetMessage("invalid id", http.StatusBadRequest)))
-		return
-	}
 	//parse applicaion_id
 
 	tokenBody := validationBody{}
-	err = json.NewDecoder(r.Body).Decode(&tokenBody)
+	err := json.NewDecoder(r.Body).Decode(&tokenBody)
 	if err != nil {
 		loggerx.Error(err)
 		errorx.Render(w, errorx.Parser(errorx.DecodeError()))
@@ -60,9 +48,9 @@ func validate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	orgToken := model.OrganisationToken{}
-	// Fetch all tokens for a organisation
+	// to need to specify the organisation id as token itself is unique
 	err = model.DB.Model(&model.OrganisationToken{}).Preload("Organisation").Where(&model.OrganisationToken{
-		Token: tokenBody.Token, OrganisationID: uint(id),
+		Token: tokenBody.Token,
 	}).First(&orgToken).Error
 
 	if err != nil {


### PR DESCRIPTION
removes unused headers like x-organisation, x-application and x-space while validating token at each level

closes #421 